### PR TITLE
fixed with zedsdk

### DIFF
--- a/lib_depth_engine.py
+++ b/lib_depth_engine.py
@@ -54,6 +54,7 @@ class DepthEngine:
         self.record = record
         self.save = save
         self.grayscale = grayscale
+        self.cfx =cuda.Device(0).make_context()
         
         # Initialize the raw data
         # Depth map without any postprocessing -> float32
@@ -153,10 +154,14 @@ class DepthEngine:
         np.copyto(self.h_input, image.ravel())
         
         # Copy the input to the GPU, execute the inference, and copy the output back to the CPU
+        self.cfx.push()
+
         cuda.memcpy_htod_async(self.d_input, self.h_input, self.cuda_stream)
         self.context.execute_async_v2(bindings=[int(self.d_input), int(self.d_output)], stream_handle=self.cuda_stream.handle)
         cuda.memcpy_dtoh_async(self.h_output, self.d_output, self.cuda_stream)
         self.cuda_stream.synchronize()
+        
+        self.cfx.pop()
         
         print(f"Inference time: {time.time() - t0:.4f}s")
         


### PR DESCRIPTION
# why
- いままで 次のコマンドが動作しなかった
```
python3 zed_cam.py --use_zed_sdk
```
- 動作しなかった理由
- ZED SDK もdepth-anything も両方GPUを利用する。
- 一方の機能が他方の機能とconflictを生じていた。
# what
- lib_depth_engine.pyへの改変
- 詳細は、差分をみてください。
## 動作確認状況
以下のコマンドを実行し、depth画像が表示されているのを確認した。
```
python3 zed_cam.py --use_zed_sdk
```