### PR TITLE
Feature/vmin vmax

### DIFF
--- a/lib_depth_engine.py
+++ b/lib_depth_engine.py
@@ -19,7 +19,10 @@ from torchvision.transforms import Compose
 from depth_anything import transform
 
 
-def depth_as_colorimage(depth_raw, vmin=None, vmax=None):
+def depth_as_colorimage(depth_raw: np.ndarray, vmin=None, vmax=None) -> np.ndarray:
+    """
+    apply color mapping with vmin, vmax
+    """
     if vmin is None:
         vmin = np.nanmin(depth_raw)
     if vmax is None:


### PR DESCRIPTION
# why
- 複数フレームでの色表示が安定していない。
- 単フレーム画像での最大値・最小値によって表示色が変わりすぎる。
# what
- 表示用の関数にvmin, vmax のオプション引数を追加した。
