### PR TITLE
Feature/same scaling

### DIFF
--- a/depth_sensing.py
+++ b/depth_sensing.py
@@ -226,11 +226,8 @@ def main(quick: bool):
                 time.sleep(5)
             else:
                 log_zed_depth = np.log(zed_depth)
-                vmin = min(np.nanmin(- log_zed_depth), np.nanmin(- predicted_log_depth2))
-                vmax = max(np.nanmax(- log_zed_depth), np.nanmax(- predicted_log_depth2))
-                cv2.imshow("zed", depth_as_colorimage(- np.log(zed_depth), vmin=vmin, vmax=vmax))
-                predicted_depth2 = np.exp(predicted_log_depth2)
-                cv2.imshow("complemented", depth_as_colorimage(- predicted_log_depth2, vmin=vmin, vmax=vmax))
+                concat_img = np.hstack((log_zed_depth, predicted_log_depth2))
+                cv2.imshow("complemented", depth_as_colorimage(- concat_img))
                 key = cv2.waitKey(1)
 
             i += 1


### PR DESCRIPTION
# why
- 表示用のグレースケールdepthをもってきても、比較には適さない。
# what
- 計算用のdepth を同一方法で変換し、連結画像を作成。
- 連結画像に対して、depth_as_colorimage()でcolor mappingすることで、同一フレーム内での、zed SDK 自体の値と、補完処理後の値で同一のスケーリングを用いるようにした。
