### PR TITLE
added install_zed_sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,13 @@ test:
 .PHONY: reformat
 reformat:
 	black *.py depanyzed/*.py test/*.py
+
+.PHONY: install_zed_sdk
+install_zed_sdk:
+	apt-get update
+	apt install sudo
+	apt install -y zip
+	apt install zstd
+	ZED_SDK_INSTALLER=ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run
+	wget --quiet -O ${ZED_SDK_INSTALLER} https://download.stereolabs.com/zedsdk/4.1/l4t35.2/jetsons
+	chmod +x ${ZED_SDK_INSTALLER} && ./${ZED_SDK_INSTALLER} -- silent


### PR DESCRIPTION
# why
- There is no description of how to install the ZED SDK when not using the Dockerfile.
# what
- Add description of install_zed_sdk in Makefile to deal with cases where Docker is not used.